### PR TITLE
Push date filters if flag is set in config

### DIFF
--- a/lib/ttl/type-exporter.js
+++ b/lib/ttl/type-exporter.js
@@ -4,7 +4,7 @@ import { querySudo } from '@lblod/mu-auth-sudo';
 import * as http from 'node:http';
 import FormData from 'form-data';
 import * as env from '../../env';
-import config from '../../config/type-export';
+import config, { constructDateFilter } from '../../config/type-export';
 import * as dbutils from '../../database-utils';
 
 /**
@@ -142,6 +142,11 @@ function whereStatementsForType(config, includeOpt = true) {
   }
 
   where.push(config.additionalFilter);
+
+  if (config.hasDateFilter && config.hasDateFilter == true) {
+    where.push(constructDateFilter());
+  }
+
   return where.join('\n');
 }
 


### PR DESCRIPTION
## PR Description

If a snippet in the config requires a date filter, set `hasDateFilter = true`. The service will pick up this check and push the date filter string that is defined in the configuration.