### PR TITLE
Only select tasks belong to the export submissions service

### DIFF
--- a/lib/export-task.js
+++ b/lib/export-task.js
@@ -160,7 +160,7 @@ export async function insertNewTask() {
           adms:status ${sparqlEscapeUri(env.STATUS_BUSY)} ;
           dct:created ${sparqlEscapeDateTime(created)} ;
           dct:modified ${sparqlEscapeDateTime(created)} ;
-          task:operation ${sparqlEscapeUri(env.JOB_OPERATION_URI)} . 
+          task:operation ${sparqlEscapeUri(env.JOB_OPERATION_URI)} .
       }
     }`;
 
@@ -210,6 +210,7 @@ export async function getTasksThatCanBeRetried() {
           a ${sparqlEscapeUri(env.TASK_TYPE)} ;
           dct:isPartOf ?jobUri ;
           mu:uuid ?uuid ;
+          task:operation ${sparqlEscapeUri(env.TASK_OPERATION_URI)} ;
           adms:status ${sparqlEscapeUri(env.STATUS_FAILED)} .
         OPTIONAL {
           ?uri export:numberOfRetries ?retries .
@@ -390,6 +391,7 @@ export async function exportTaskByUuid(uuid) {
         ?uri
           a ${sparqlEscapeUri(env.TASK_TYPE)} ;
           mu:uuid ${sparqlEscapeString(uuid)} ;
+          task:operation ${sparqlEscapeUri(env.TASK_OPERATION_URI)} ;
           adms:status ?status .
         OPTIONAL {
           ?uri export:numberOfRetries ?retries .


### PR DESCRIPTION
## PR Description

When previously selecting tasks, they were only selected based on their types, which meant tasks from other services were also picked up (e.g., tasks from the automatic submissions service, etc.).

We now also filter on `task:operation` to only fetch the relevant tasks.