### PR TITLE
enhance batch job + add missing env vars to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The following environment variables can be configured:
   `EXPORT_TTL_BATCH_SIZE * number_of_matching_triples` doesn't exceed the
   maximum number of triples return by the database (e.g. `ResultSetMaxRows` in
   Virtuoso).
+* `MAX_RETRIES_BATCH_EXPORT_STEP`: number of retries allowed for a query to `EXPORT_SPARQL_ENDPOINT`. By default no retries are allowed.  
+* `SLEEP_INTERVAL`: by default, the service wait 1000ms between every query to the `EXPORT_SPARQL_ENDPOINT`. Adjust this for a longer delay.
 * `RETRY_CRON_PATTERN`: cron pattern to configure the frequency of the function
   that retries failed tasks. The pattern follows the format as specified in
   [node-cron](https://www.npmjs.com/package/cron#available-cron-patterns).
@@ -148,7 +150,10 @@ The following environment variables can be configured:
 * `EXPORT_CLASSIFICATION_URI`: the classification of the export, to ease
   filtering. Defaults to:
   `http://redpencil.data.gift/id/exports/concept/GenericExport`
-* `MU_SPARQL_ENDPOINT`: Sparql endpoint to query. Defaults to: `http://virtuoso:8890/sparql`  
+* `MU_SPARQL_ENDPOINT`: Sparql endpoint to use for jobs and file metadata. Defaults to: `http://virtuoso:8890/sparql`  
+* `EXPORT_SPARQL_ENDPOINT`: Sparql endpoint to export data from. Defaults to: `MU_SPARQL_ENDPOINT`
+* `EXPORT_WITH_EXTRA_SUBQUERY`: default false, if set to true, the export query will use an extra subquery, which is sometimes needed to avoid virtuoso error `Sorted TOP clause specifies more than X rows to sort. 
+Only X are allowed.`
 
 ## REST API
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ services:
     image: lblod/mandaten-download-generator-service:1.0.0
     volumes:
       - ./data/files:/share
-      - ./config/type-exports.js:/config/type-exports.js
+      - ./config/type-export.js:/config/type-export.js
 ```
 
 Don't forget to update the dispatcher configuration to route requests to the
@@ -148,6 +148,7 @@ The following environment variables can be configured:
 * `EXPORT_CLASSIFICATION_URI`: the classification of the export, to ease
   filtering. Defaults to:
   `http://redpencil.data.gift/id/exports/concept/GenericExport`
+* `MU_SPARQL_ENDPOINT`: Sparql endpoint to query. Defaults to: `http://virtuoso:8890/sparql`  
 
 ## REST API
 

--- a/env.js
+++ b/env.js
@@ -23,9 +23,20 @@ export const MU_SPARQL_ENDPOINT = envvar
   .default('http://virtuoso:8890/sparql')
   .asUrlString();
 
+  export const EXPORT_SPARQL_ENDPOINT = envvar
+  .get('EXPORT_SPARQL_ENDPOINT')
+  .example('http://virtuoso:8890/sparql')
+  .default(MU_SPARQL_ENDPOINT)
+  .asUrlString();  
+
 export const EXPORT_TTL_BATCH_SIZE = envvar
   .get('EXPORT_TTL_BATCH_SIZE')
   .default('1000')
+  .asIntPositive();
+
+export const MAX_RETRIES_BATCH_EXPORT_STEP = envvar
+  .get('MAX_RETRIES_BATCH_EXPORT_STEP')
+  .default('0')
   .asIntPositive();
 
 export const MAX_NUMBER_OF_RETRIES = envvar
@@ -93,6 +104,11 @@ export const SLEEP_INTERVAL = envvar
   .default('1000') // 1 second
   .asIntPositive();
 
+export const EXPORT_WITH_EXTRA_SUBQUERY = envvar
+  .get('EXPORT_WITH_EXTRA_SUBQUERY')
+  .default('false')
+  .asBool();
+
 // Constants
 
 export const STATUS_BUSY =
@@ -142,5 +158,10 @@ export const JOB_CREATOR_URI =
 
 export const sparqlConnectionOptions = {
   sparqlEndpoint: MU_SPARQL_ENDPOINT,
+  mayRetry: true,
+};
+
+export const exportSparqlConnectionOptions = {
+  sparqlEndpoint: EXPORT_SPARQL_ENDPOINT,
   mayRetry: true,
 };

--- a/lib/ttl/type-exporter.js
+++ b/lib/ttl/type-exporter.js
@@ -23,7 +23,27 @@ export default async function exportAsync(file) {
     console.log(`Exporting 0/${count} of ${typeConfig.type}`);
 
     let offset = 0;
-    const query = `
+    const query = env.EXPORT_WITH_EXTRA_SUBQUERY ?
+      // extra SELECT sub-query to avoid to avoid virtuoso limits
+      `
+      ${prefixes}
+      CONSTRUCT {
+        ${constructStatementsForType(typeConfig)}
+      }
+      WHERE {
+        {
+          SELECT DISTINCT ?resource WHERE {
+            SELECT DISTINCT ?resource WHERE {
+              ${whereStatementsForType(typeConfig, false)}
+            }
+            ORDER BY ?resource
+          } LIMIT ${env.EXPORT_TTL_BATCH_SIZE}
+            OFFSET %OFFSET
+        }
+        ${whereStatementsForType(typeConfig)}
+      }`:
+      // default (normal) query
+      `
       ${prefixes}
       CONSTRUCT {
         ${constructStatementsForType(typeConfig)}
@@ -41,10 +61,30 @@ export default async function exportAsync(file) {
       }`;
 
     while (offset < count) {
-      await appendBatch(tmpFile, query, offset);
+      const start = new Date();
+      let retryCount = 0;
+      let success = false;
+      while (!success && retryCount <= env.MAX_RETRIES_BATCH_EXPORT_STEP) {
+        try {
+          await appendBatch(tmpFile, query, offset);
+          success = true;
+        } catch (error) {
+          console.log(`Error with fetching batch with offset ${offset}: ${error}`);
+          retryCount++;
+          if(retryCount <= env.MAX_RETRIES_BATCH_EXPORT_STEP) {
+            console.log(`Retrying (retry ${retryCount}/${env.MAX_RETRIES_BATCH_EXPORT_STEP}) in ${env.SLEEP_INTERVAL} ms.`);
+            await dbutils.sleep(env.SLEEP_INTERVAL);
+          }
+        }
+      }
+      if(retryCount > env.MAX_RETRIES_BATCH_EXPORT_STEP) {
+        throw new Error(`Failed after ${retryCount}/${env.MAX_RETRIES_BATCH_EXPORT_STEP + 1} attempts at offset ${offset}.`);
+      }
+
       offset = offset + env.EXPORT_TTL_BATCH_SIZE;
+      const elapsed = ((new Date()).getTime() - start.getTime()) /1000;
       console.log(
-        `Constructed ${offset < count ? offset : count}/${count} of ${typeConfig.type}`,
+        `Constructed ${offset < count ? offset : count}/${count} of ${typeConfig.type} in ${elapsed}s`,
       );
       console.log(
         `Sleeping ${env.SLEEP_INTERVAL} ms before fetching the next batch.`,
@@ -66,7 +106,7 @@ async function countForType(prefixes, config) {
       ${whereStatementsForType(config, false)}
     }`,
     {},
-    env.sparqlConnectionOptions,
+    env.exportSparqlConnectionOptions,
   );
 
   return parseInt(queryResult.results.bindings[0].count.value);
@@ -75,11 +115,12 @@ async function countForType(prefixes, config) {
 function appendBatch(file, query, offset = 0) {
   return new Promise((resolve, reject) => {
     const format = 'text/turtle';
-    const url = new URL(env.MU_SPARQL_ENDPOINT);
+    const url = new URL(env.EXPORT_SPARQL_ENDPOINT);
     const fileStream = fsSync.createWriteStream(file, { flags: 'a' });
     const formData = new FormData();
     formData.append('format', format);
     formData.append('query', query.replace('%OFFSET', offset));
+
     const req = http.request(
       url,
       {


### PR DESCRIPTION
all these changes are not active by default, so they are *non-breaking* changes.

- add missing env vars to docs
- adds env var to specify the endpoint for exporting (which means it can be external)
- add retry mechanism for the batching queries. This is disabled by default.
- add `EXPORT_WITH_EXTRA_SUBQUERY`. When true, the query gets an *extra* subquery, which is needed for Virtuoso databases that might set their max offset to 10k (or higher).