### PR TITLE
Hotfix/ensure new lines after each chunk. [Don't merge]

### DIFF
--- a/.woodpecker/feature.yml
+++ b/.woodpecker/feature.yml
@@ -1,0 +1,14 @@
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: "${CI_REPO_OWNER%%io}/${CI_REPO_NAME}"
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: push
+    branch: [feature/*]
+

--- a/.woodpecker/latest.yml
+++ b/.woodpecker/latest.yml
@@ -1,0 +1,14 @@
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: "${CI_REPO_OWNER%%io}/${CI_REPO_NAME}"
+      tags: latest
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: push
+    branch: [master, main]
+

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -1,0 +1,14 @@
+steps:
+  release:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: "${CI_REPO_OWNER%%io}/${CI_REPO_NAME}"
+      tags: "${CI_COMMIT_TAG##v}"
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: tag
+    ref: refs/tags/v*
+

--- a/lib/csv/sparql-exporter.js
+++ b/lib/csv/sparql-exporter.js
@@ -58,6 +58,7 @@ async function appendBatch(file, query, offset = 0, limit = 1000, writeColumnHea
   });
 
   fs.appendFileSync(file, proccessedText.join('\n'));
+  fs.appendFileSync(file, '\n'); //Ensure new line after each batch
   return nbOfRecords > 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mandaten-export-generator-service",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Microservice to generate the export files for mandatendatabank",
   "dependencies": {
     "cron": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mandaten-export-generator-service",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Microservice to generate the export files for mandatendatabank",
   "dependencies": {
     "cron": "^1.3.0",


### PR DESCRIPTION
There is a bug in the current version (v0.3.6) of this service used by https://github.com/lblod/app-mandatendatabank
Between chunks, no new lines are added in the CSV, which breaks the CSV. 
This PR fixes this. It seems the problem is not present in the latest versions of this service, but bumping this in https://github.com/lblod/app-mandatendatabank will be a bigger change since the data model changed.
Original ticket https://binnenland.atlassian.net/browse/DL-6768
Follow up ticket: https://binnenland.atlassian.net/browse/DL-6785